### PR TITLE
fix: Use camelCase for on-disk storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to programming agents when working with code in this
 
 Rust implementation of filesystem storage clients for Crawlee crawlers, with Python and Node.js bindings. The project follows the same structure as [apify/impit](https://github.com/apify/impit) — a Cargo workspace with a core library crate and per-language binding crates.
 
-The Rust library implements three storage clients (`FileSystemDatasetClient`, `FileSystemKeyValueStoreClient`, `FileSystemRequestQueueClient`) that are byte-for-byte filesystem-compatible with the Python implementations in [crawlee-py](https://github.com/apify/crawlee-py). Requests are treated as opaque JSON blobs (requiring at minimum a `uniqueKey` field).
+The Rust library implements three storage clients (`FileSystemDatasetClient`, `FileSystemKeyValueStoreClient`, `FileSystemRequestQueueClient`) with a filesystem layout matching [crawlee (JS)](https://github.com/apify/crawlee). Requests are treated as opaque JSON blobs (requiring at minimum a `uniqueKey` field).
 
 ## Development Commands
 
@@ -82,7 +82,7 @@ There is no `StorageClient` facade or trait in Rust. The three client structs ar
 
 **KVS value model**: KVS record values use the `KvsValue` enum (`None`, `Json(Value)`, `Text(String)`, `Binary(Vec<u8>)`) instead of `serde_json::Value`. This avoids base64-encoding binary data at the core level — each binding layer converts `KvsValue` variants directly to native types (e.g. `Binary` → Python `bytes`, Node.js `Buffer`).
 
-### Filesystem Layout (must match Python exactly)
+### Filesystem Layout
 
 ```
 {storage_dir}/
@@ -103,16 +103,18 @@ There is no `StorageClient` facade or trait in Rust. The three client structs ar
 
 ### Key Compatibility Constraints
 
-These must be preserved for drop-in compatibility with the Python `FileSystemStorageClient`:
+These must be preserved for compatibility with the JS Crawlee `MemoryStorage` on-disk format:
 
 - **JSON formatting**: Pretty-printed, 2-space indent, non-ASCII preserved (`ensure_ascii=False` equivalent). Use `serde_json::ser::PrettyFormatter::with_indent(b"  ")`.
-- **Metadata field names**: snake_case in JSON (e.g., `item_count`, `created_at`), matching Python's `model_dump()` output.
-- **Datetime format**: `2024-01-15T10:30:00.123456+00:00` — 6 fractional digits, `+00:00` suffix for UTC.
+- **Metadata field names**: camelCase in JSON (e.g., `itemCount`, `accessedAt`, `contentType`), matching JS conventions. Rust struct fields stay snake_case with `#[serde(rename_all = "camelCase")]`. All multi-word fields also have `#[serde(alias = "snake_case")]` so legacy files written by the old Python `FileSystemStorageClient` can still be loaded.
+- **Datetime format**: Written as `2024-01-15T10:30:00.123456+00:00` — 6 fractional digits (microsecond precision), `+00:00` suffix for UTC. Deserialization also accepts JS-style `Z` suffix (e.g., `2024-01-15T10:30:00.123Z`).
+- **Directory names**: snake_case (`datasets`, `key_value_stores`, `request_queues`) — unchanged, matching both JS and Python.
 - **KVS key encoding**: `percent_encoding::utf8_percent_encode(key, NON_ALPHANUMERIC)` — equivalent to Python's `urllib.parse.quote(key, safe='')`.
 - **RQ filenames**: `sha256(unique_key_bytes).hexdigest()[:15] + ".json"`.
 - **Atomic writes**: Write to temp file in same directory, then `rename()`.
 - **`application/x-none` sentinel**: KVS uses this custom MIME type for `None`/null values (empty file on disk).
 - **`serde_json` `preserve_order` feature**: Enabled to maintain JSON key insertion order (matching Python dict ordering).
+- **Python bindings return camelCase**: The Python bindings pass camelCase dicts directly to Python. The Pydantic models in crawlee-python accept both camelCase (via alias) and snake_case (via field name) thanks to `validate_by_name=True, validate_by_alias=True`.
 
 ### Python Bindings
 

--- a/crawlee-storage-python/src/lib.rs
+++ b/crawlee-storage-python/src/lib.rs
@@ -114,6 +114,9 @@ fn storage_err(e: crawlee_storage::utils::StorageError) -> PyErr {
 }
 
 /// Convert a serde_json metadata struct to a Python dict.
+/// Keys are camelCase (matching the on-disk format). The Python Pydantic models
+/// accept both camelCase aliases and snake_case field names via
+/// `validate_by_name=True, validate_by_alias=True`.
 fn metadata_to_py<T: serde::Serialize>(py: Python<'_>, meta: &T) -> PyResult<Py<PyAny>> {
     let val = serde_json::to_value(meta).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     value_to_py(py, &val)

--- a/crawlee-storage/src/dataset.rs
+++ b/crawlee-storage/src/dataset.rs
@@ -316,10 +316,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        client
-            .push_data(serde_json::json!({"x": 1}))
-            .await
-            .unwrap();
+        client.push_data(serde_json::json!({"x": 1})).await.unwrap();
 
         // Read the raw metadata JSON from disk and verify camelCase keys
         let raw = tokio::fs::read_to_string(client.metadata_path())
@@ -329,16 +326,40 @@ mod tests {
         let obj = parsed.as_object().unwrap();
 
         // Should have camelCase keys
-        assert!(obj.contains_key("itemCount"), "expected 'itemCount' key, got: {raw}");
-        assert!(obj.contains_key("accessedAt"), "expected 'accessedAt' key, got: {raw}");
-        assert!(obj.contains_key("createdAt"), "expected 'createdAt' key, got: {raw}");
-        assert!(obj.contains_key("modifiedAt"), "expected 'modifiedAt' key, got: {raw}");
+        assert!(
+            obj.contains_key("itemCount"),
+            "expected 'itemCount' key, got: {raw}"
+        );
+        assert!(
+            obj.contains_key("accessedAt"),
+            "expected 'accessedAt' key, got: {raw}"
+        );
+        assert!(
+            obj.contains_key("createdAt"),
+            "expected 'createdAt' key, got: {raw}"
+        );
+        assert!(
+            obj.contains_key("modifiedAt"),
+            "expected 'modifiedAt' key, got: {raw}"
+        );
 
         // Should NOT have snake_case keys
-        assert!(!obj.contains_key("item_count"), "unexpected 'item_count' key");
-        assert!(!obj.contains_key("accessed_at"), "unexpected 'accessed_at' key");
-        assert!(!obj.contains_key("created_at"), "unexpected 'created_at' key");
-        assert!(!obj.contains_key("modified_at"), "unexpected 'modified_at' key");
+        assert!(
+            !obj.contains_key("item_count"),
+            "unexpected 'item_count' key"
+        );
+        assert!(
+            !obj.contains_key("accessed_at"),
+            "unexpected 'accessed_at' key"
+        );
+        assert!(
+            !obj.contains_key("created_at"),
+            "unexpected 'created_at' key"
+        );
+        assert!(
+            !obj.contains_key("modified_at"),
+            "unexpected 'modified_at' key"
+        );
     }
 
     #[tokio::test]
@@ -372,10 +393,7 @@ mod tests {
         assert_eq!(meta.item_count, 5);
 
         // After any write, it should re-serialize as camelCase
-        client
-            .push_data(serde_json::json!({"x": 1}))
-            .await
-            .unwrap();
+        client.push_data(serde_json::json!({"x": 1})).await.unwrap();
         let raw = tokio::fs::read_to_string(client.metadata_path())
             .await
             .unwrap();

--- a/crawlee-storage/src/dataset.rs
+++ b/crawlee-storage/src/dataset.rs
@@ -307,6 +307,91 @@ mod tests {
     use tempfile::TempDir;
 
     #[tokio::test]
+    async fn test_on_disk_metadata_uses_camel_case() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        let client =
+            FileSystemDatasetClient::open(None, Some("test-ds".to_string()), None, storage_dir)
+                .await
+                .unwrap();
+
+        client
+            .push_data(serde_json::json!({"x": 1}))
+            .await
+            .unwrap();
+
+        // Read the raw metadata JSON from disk and verify camelCase keys
+        let raw = tokio::fs::read_to_string(client.metadata_path())
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let obj = parsed.as_object().unwrap();
+
+        // Should have camelCase keys
+        assert!(obj.contains_key("itemCount"), "expected 'itemCount' key, got: {raw}");
+        assert!(obj.contains_key("accessedAt"), "expected 'accessedAt' key, got: {raw}");
+        assert!(obj.contains_key("createdAt"), "expected 'createdAt' key, got: {raw}");
+        assert!(obj.contains_key("modifiedAt"), "expected 'modifiedAt' key, got: {raw}");
+
+        // Should NOT have snake_case keys
+        assert!(!obj.contains_key("item_count"), "unexpected 'item_count' key");
+        assert!(!obj.contains_key("accessed_at"), "unexpected 'accessed_at' key");
+        assert!(!obj.contains_key("created_at"), "unexpected 'created_at' key");
+        assert!(!obj.contains_key("modified_at"), "unexpected 'modified_at' key");
+    }
+
+    #[tokio::test]
+    async fn test_loads_legacy_snake_case_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        // Write a legacy snake_case metadata file (as the old Python client would)
+        let ds_dir = storage_dir.join("datasets").join("legacy-ds");
+        fs::create_dir_all(&ds_dir).await.unwrap();
+        let legacy_meta = r#"{
+  "id": "abc123",
+  "name": "legacy-ds",
+  "accessed_at": "2024-01-15T10:30:00.123456+00:00",
+  "created_at": "2024-01-15T10:30:00.123456+00:00",
+  "modified_at": "2024-01-15T10:30:00.123456+00:00",
+  "item_count": 5
+}"#;
+        fs::write(ds_dir.join(METADATA_FILENAME), legacy_meta)
+            .await
+            .unwrap();
+
+        // Should load successfully despite snake_case keys
+        let client =
+            FileSystemDatasetClient::open(None, Some("legacy-ds".to_string()), None, storage_dir)
+                .await
+                .unwrap();
+
+        let meta = client.get_metadata().await;
+        assert_eq!(meta.base.id, "abc123");
+        assert_eq!(meta.item_count, 5);
+
+        // After any write, it should re-serialize as camelCase
+        client
+            .push_data(serde_json::json!({"x": 1}))
+            .await
+            .unwrap();
+        let raw = tokio::fs::read_to_string(client.metadata_path())
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let obj = parsed.as_object().unwrap();
+        assert!(
+            obj.contains_key("itemCount"),
+            "after rewrite, should use camelCase: {raw}"
+        );
+        assert!(
+            !obj.contains_key("item_count"),
+            "after rewrite, should not have snake_case: {raw}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_create_and_push_data() {
         let temp_dir = TempDir::new().unwrap();
         let storage_dir = temp_dir.path();

--- a/crawlee-storage/src/key_value_store.rs
+++ b/crawlee-storage/src/key_value_store.rs
@@ -414,6 +414,41 @@ mod tests {
     use tempfile::TempDir;
 
     #[tokio::test]
+    async fn test_on_disk_sidecar_uses_camel_case() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        let client = FileSystemKeyValueStoreClient::open(None, None, None, storage_dir)
+            .await
+            .unwrap();
+
+        client
+            .set_value(
+                "test-key",
+                KvsValue::Json(serde_json::json!({"x": 1})),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Read the sidecar metadata
+        let encoded = encode_key("test-key");
+        let sidecar_path = client.path().join(format!("{encoded}.{METADATA_FILENAME}"));
+        let raw = tokio::fs::read_to_string(&sidecar_path).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let obj = parsed.as_object().unwrap();
+
+        assert!(obj.contains_key("contentType"), "expected 'contentType', got: {raw}");
+        assert!(!obj.contains_key("content_type"), "unexpected 'content_type'");
+
+        // Store metadata should also be camelCase
+        let store_raw = tokio::fs::read_to_string(client.metadata_path()).await.unwrap();
+        let store_parsed: serde_json::Value = serde_json::from_str(&store_raw).unwrap();
+        let store_obj = store_parsed.as_object().unwrap();
+        assert!(store_obj.contains_key("accessedAt"), "expected 'accessedAt' in store metadata, got: {store_raw}");
+    }
+
+    #[tokio::test]
     async fn test_create_and_set_value() {
         let temp_dir = TempDir::new().unwrap();
         let storage_dir = temp_dir.path();

--- a/crawlee-storage/src/key_value_store.rs
+++ b/crawlee-storage/src/key_value_store.rs
@@ -438,14 +438,25 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let obj = parsed.as_object().unwrap();
 
-        assert!(obj.contains_key("contentType"), "expected 'contentType', got: {raw}");
-        assert!(!obj.contains_key("content_type"), "unexpected 'content_type'");
+        assert!(
+            obj.contains_key("contentType"),
+            "expected 'contentType', got: {raw}"
+        );
+        assert!(
+            !obj.contains_key("content_type"),
+            "unexpected 'content_type'"
+        );
 
         // Store metadata should also be camelCase
-        let store_raw = tokio::fs::read_to_string(client.metadata_path()).await.unwrap();
+        let store_raw = tokio::fs::read_to_string(client.metadata_path())
+            .await
+            .unwrap();
         let store_parsed: serde_json::Value = serde_json::from_str(&store_raw).unwrap();
         let store_obj = store_parsed.as_object().unwrap();
-        assert!(store_obj.contains_key("accessedAt"), "expected 'accessedAt' in store metadata, got: {store_raw}");
+        assert!(
+            store_obj.contains_key("accessedAt"),
+            "expected 'accessedAt' in store metadata, got: {store_raw}"
+        );
     }
 
     #[tokio::test]

--- a/crawlee-storage/src/models.rs
+++ b/crawlee-storage/src/models.rs
@@ -2,30 +2,16 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Format string for datetime serialization compatible with Python's `datetime.isoformat()`.
-/// Python produces: `2024-01-15T10:30:00.123456` (6 fractional digits, no trailing zeros trimmed).
-/// We use chrono's default which also produces 6-digit microsecond precision for UTC datetimes.
+/// Format string for datetime serialization.
+/// Produces 6 fractional digits (microsecond precision) with `+00:00` UTC suffix.
+/// Example: `2024-01-15T10:30:00.123456+00:00`
 const DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.6f";
 
 pub(crate) fn serialize_datetime<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    // Python's `str(datetime)` / `datetime.isoformat()` for UTC-aware datetimes produces
-    // something like "2024-01-15 10:30:00.123456+00:00" when using default=str in json.dumps,
-    // but the actual crawlee code uses `datetime.now(timezone.utc)` and `default=str` which
-    // produces "2024-01-15 10:30:00.123456+00:00".
-    // However, looking at the actual metadata files, they use ISO format.
-    // We'll format to match Python: "2024-01-15T10:30:00.123456"
-    // The Python code uses `default=str` which calls `str()` on datetime, producing the space-separated form.
-    // But Pydantic's model_dump with mode='python' keeps datetime objects, and json.dumps with default=str
-    // converts them. Let's check what Python actually writes...
-    // Python: json.dumps(..., default=str) -> str(datetime_obj) -> "2024-01-15 10:30:00.123456+00:00"
-    // Wait, that has a space not T. Let me re-check.
-    // Actually Python's `str(datetime)` uses isoformat with sep='T' since Python 3.
-    // `datetime.now(timezone.utc)` -> `str()` -> "2024-01-15T10:30:00.123456+00:00"
     let formatted = dt.format(DATETIME_FORMAT).to_string();
-    // Append "+00:00" to match Python's UTC timezone representation
     serializer.serialize_str(&format!("{formatted}+00:00"))
 }
 
@@ -34,12 +20,18 @@ where
     D: serde::Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    // Try parsing various formats Python might produce
-    // Format: "2024-01-15T10:30:00.123456+00:00"
+    // Try parsing various formats:
+    // 1. With timezone offset: "2024-01-15T10:30:00.123456+00:00"
+    // 2. With Z suffix (JS format): "2024-01-15T10:30:00.123Z"
+    // 3. Without timezone: "2024-01-15T10:30:00.123456"
     DateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f%:z")
         .map(|dt| dt.with_timezone(&Utc))
         .or_else(|_| {
-            // Fallback: "2024-01-15T10:30:00.123456"
+            // "2024-01-15T10:30:00.123Z" — chrono's parse_from_rfc3339 handles this
+            DateTime::parse_from_rfc3339(&s).map(|dt| dt.with_timezone(&Utc))
+        })
+        .or_else(|_| {
+            // Fallback: no timezone info, assume UTC
             chrono::NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f")
                 .map(|ndt| ndt.and_utc())
         })
@@ -53,23 +45,32 @@ fn datetime_now() -> DateTime<Utc> {
 // ─── Storage Metadata (base) ────────────────────────────────────────────────
 
 /// Base metadata shared by all storage types.
-/// Field names use snake_case to match Python's `model_dump()` output (which does NOT use by_alias).
+///
+/// On-disk JSON uses camelCase field names (e.g. `accessedAt`, `createdAt`, `modifiedAt`).
+/// Snake_case aliases are accepted on deserialization for backward compatibility
+/// with files written by the old Python `FileSystemStorageClient`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageMetadata {
     pub id: String,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(
+        rename = "accessedAt",
+        alias = "accessed_at",
         serialize_with = "serialize_datetime",
         deserialize_with = "deserialize_datetime"
     )]
     pub accessed_at: DateTime<Utc>,
     #[serde(
+        rename = "createdAt",
+        alias = "created_at",
         serialize_with = "serialize_datetime",
         deserialize_with = "deserialize_datetime"
     )]
     pub created_at: DateTime<Utc>,
     #[serde(
+        rename = "modifiedAt",
+        alias = "modified_at",
         serialize_with = "serialize_datetime",
         deserialize_with = "deserialize_datetime"
     )]
@@ -95,6 +96,7 @@ impl StorageMetadata {
 pub struct DatasetMetadata {
     #[serde(flatten)]
     pub base: StorageMetadata,
+    #[serde(rename = "itemCount", alias = "item_count")]
     pub item_count: usize,
 }
 
@@ -128,6 +130,7 @@ impl KeyValueStoreMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyValueStoreRecordMetadata {
     pub key: String,
+    #[serde(rename = "contentType", alias = "content_type")]
     pub content_type: String,
     #[serde(default)]
     pub size: Option<usize>,
@@ -163,9 +166,13 @@ pub struct KeyValueStoreRecord {
 pub struct RequestQueueMetadata {
     #[serde(flatten)]
     pub base: StorageMetadata,
+    #[serde(rename = "hadMultipleClients", alias = "had_multiple_clients")]
     pub had_multiple_clients: bool,
+    #[serde(rename = "handledRequestCount", alias = "handled_request_count")]
     pub handled_request_count: usize,
+    #[serde(rename = "pendingRequestCount", alias = "pending_request_count")]
     pub pending_request_count: usize,
+    #[serde(rename = "totalRequestCount", alias = "total_request_count")]
     pub total_request_count: usize,
 }
 
@@ -183,6 +190,8 @@ impl RequestQueueMetadata {
 
 // ─── Dataset Items List Page ────────────────────────────────────────────────
 
+/// This struct is never deserialized from disk — it's only constructed in Rust
+/// and serialized to pass to the binding layer. No aliases needed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatasetItemsListPage {
     pub count: usize,
@@ -223,16 +232,22 @@ pub struct KvsKeysPage {
 
 // ─── Request Queue Operation Results ────────────────────────────────────────
 
+/// These structs are never deserialized from disk — they're constructed in Rust
+/// and serialized to pass to the binding layer. No aliases needed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessedRequest {
     pub id: Option<String>,
+    #[serde(rename = "uniqueKey")]
     pub unique_key: String,
+    #[serde(rename = "wasAlreadyPresent")]
     pub was_already_present: bool,
+    #[serde(rename = "wasAlreadyHandled")]
     pub was_already_handled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnprocessedRequest {
+    #[serde(rename = "uniqueKey")]
     pub unique_key: String,
     pub url: String,
     #[serde(default)]
@@ -241,30 +256,36 @@ pub struct UnprocessedRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddRequestsResponse {
+    #[serde(rename = "processedRequests")]
     pub processed_requests: Vec<ProcessedRequest>,
+    #[serde(rename = "unprocessedRequests")]
     pub unprocessed_requests: Vec<UnprocessedRequest>,
 }
 
 // ─── Request Queue Internal State ───────────────────────────────────────────
 
-/// Internal state for the request queue, persisted via callbacks.
+/// Internal state for the request queue, persisted to KVS as JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestQueueState {
-    #[serde(default)]
+    #[serde(default, rename = "sequenceCounter", alias = "sequence_counter")]
     pub sequence_counter: i64,
-    #[serde(default)]
+    #[serde(
+        default,
+        rename = "forefrontSequenceCounter",
+        alias = "forefront_sequence_counter"
+    )]
     pub forefront_sequence_counter: i64,
     /// unique_key -> sequence_number
-    #[serde(default)]
+    #[serde(default, rename = "forefrontRequests", alias = "forefront_requests")]
     pub forefront_requests: serde_json::Map<String, Value>,
     /// unique_key -> sequence_number
-    #[serde(default)]
+    #[serde(default, rename = "regularRequests", alias = "regular_requests")]
     pub regular_requests: serde_json::Map<String, Value>,
     /// Set of unique_keys currently in progress
-    #[serde(default)]
+    #[serde(default, rename = "inProgressRequests", alias = "in_progress_requests")]
     pub in_progress_requests: Vec<String>,
     /// Set of unique_keys that have been handled
-    #[serde(default)]
+    #[serde(default, rename = "handledRequests", alias = "handled_requests")]
     pub handled_requests: Vec<String>,
 }
 

--- a/crawlee-storage/src/request_queue.rs
+++ b/crawlee-storage/src/request_queue.rs
@@ -498,10 +498,7 @@ impl FileSystemRequestQueueClient {
         let now = Utc::now();
         let handled_at_str = now.format("%Y-%m-%dT%H:%M:%S%.6f+00:00").to_string();
         if let Value::Object(ref mut map) = request {
-            map.insert(
-                "handledAt".to_string(),
-                Value::String(handled_at_str),
-            );
+            map.insert("handledAt".to_string(), Value::String(handled_at_str));
         }
 
         // Write updated request file

--- a/crawlee-storage/src/request_queue.rs
+++ b/crawlee-storage/src/request_queue.rs
@@ -494,15 +494,14 @@ impl FileSystemRequestQueueClient {
             return Ok(None);
         }
 
-        // Set handled_at timestamp
+        // Set handledAt timestamp
         let now = Utc::now();
         let handled_at_str = now.format("%Y-%m-%dT%H:%M:%S%.6f+00:00").to_string();
         if let Value::Object(ref mut map) = request {
             map.insert(
                 "handledAt".to_string(),
-                Value::String(handled_at_str.clone()),
+                Value::String(handled_at_str),
             );
-            map.insert("handled_at".to_string(), Value::String(handled_at_str));
         }
 
         // Write updated request file


### PR DESCRIPTION
- The code here was initially modelled after crawlee-python, which was supposed to use camelCase to match the JS storage format, but didn't (https://github.com/apify/crawlee-python/issues/1844)
- This PR changes it to camelCase (even though the storage folders are snake_case)
