### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -35,7 +35,7 @@ jobs:
       tag_name: ${{ steps.release_metadata.outputs.tag_name }}
       changelog: ${{ steps.release_metadata.outputs.changelog }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.1.0
+      - uses: apify/actions/git-cliff-release@v1.1.1
         id: release_metadata
         name: Prepare release metadata
         with:

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -35,7 +35,7 @@ jobs:
       tag_name: ${{ steps.release_metadata.outputs.tag_name }}
       changelog: ${{ steps.release_metadata.outputs.changelog }}
     steps:
-      - uses: apify/workflows/git-cliff-release@main
+      - uses: apify/actions/git-cliff-release@v1.0.0
         id: release_metadata
         name: Prepare release metadata
         with:

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -35,7 +35,7 @@ jobs:
       tag_name: ${{ steps.release_metadata.outputs.tag_name }}
       changelog: ${{ steps.release_metadata.outputs.changelog }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.1.1
+      - uses: apify/actions/git-cliff-release@v1.1.2
         id: release_metadata
         name: Prepare release metadata
         with:

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -35,7 +35,7 @@ jobs:
       tag_name: ${{ steps.release_metadata.outputs.tag_name }}
       changelog: ${{ steps.release_metadata.outputs.changelog }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.0.0
+      - uses: apify/actions/git-cliff-release@v1.1.0
         id: release_metadata
         name: Prepare release metadata
         with:


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.