### PR TITLE
chore: Clean up the API surface

### DIFF
--- a/crawlee-storage-node/index.js
+++ b/crawlee-storage-node/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-android-arm64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-android-arm-eabi')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-win32-x64-gnu')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-win32-x64-msvc')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-win32-ia32-msvc')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-win32-arm64-msvc')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@crawlee/fs-storage-native-darwin-universal')
       const bindingPackageVersion = require('@crawlee/fs-storage-native-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-darwin-x64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-darwin-arm64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-freebsd-x64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-freebsd-arm64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-x64-musl')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-x64-gnu')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-arm64-musl')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-arm64-gnu')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-arm-musleabihf')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-loong64-musl')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-loong64-gnu')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-riscv64-musl')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@crawlee/fs-storage-native-linux-riscv64-gnu')
           const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-linux-ppc64-gnu')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-linux-s390x-gnu')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-openharmony-arm64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-openharmony-x64')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@crawlee/fs-storage-native-openharmony-arm')
         const bindingPackageVersion = require('@crawlee/fs-storage-native-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.1.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.1.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crawlee-storage-node/src/lib.rs
+++ b/crawlee-storage-node/src/lib.rs
@@ -134,7 +134,7 @@ impl FileSystemDatasetClient {
             .inner
             .get_data(
                 offset.unwrap_or(0) as usize,
-                limit.map_or(999_999_999_999_usize, |l| l as usize),
+                limit.map(|l| l as usize),
                 desc.unwrap_or(false),
                 skip_empty.unwrap_or(false),
             )

--- a/crawlee-storage-python/python/crawlee_storage/_native/__init__.pyi
+++ b/crawlee-storage-python/python/crawlee_storage/_native/__init__.pyi
@@ -120,7 +120,7 @@ class FileSystemDatasetClient:
     async def get_data(
         self,
         offset: builtins.int = 0,
-        limit: builtins.int = 999999999999,
+        limit: typing.Optional[builtins.int] = None,
         desc: builtins.bool = False,
         skip_empty: builtins.bool = False,
     ) -> DatasetItemsListPage: ...

--- a/crawlee-storage-python/src/lib.rs
+++ b/crawlee-storage-python/src/lib.rs
@@ -435,13 +435,13 @@ impl FileSystemDatasetClient {
         })
     }
 
-    #[pyo3(signature = (offset=0, limit=999999999999, desc=false, skip_empty=false))]
+    #[pyo3(signature = (offset=0, limit=None, desc=false, skip_empty=false))]
     #[gen_stub(override_return_type(type_repr = "DatasetItemsListPage"))]
     fn get_data<'py>(
         &self,
         py: Python<'py>,
         offset: usize,
-        limit: usize,
+        limit: Option<usize>,
         desc: bool,
         skip_empty: bool,
     ) -> PyResult<Bound<'py, pyo3::PyAny>> {

--- a/crawlee-storage/src/dataset.rs
+++ b/crawlee-storage/src/dataset.rs
@@ -9,12 +9,18 @@ use crate::clock::{system_clock, ClockRef};
 use crate::models::{DatasetItemsListPage, DatasetItemsPage, DatasetMetadata};
 use crate::utils::{
     atomic_write, crypto_random_object_id, find_storage_by_id, json_dumps, json_dumps_value,
-    validate_exclusive_args, Result, StorageError, METADATA_FILENAME,
+    validate_exclusive_args, validate_subdirectory, Result, StorageError, METADATA_FILENAME,
 };
 
 const STORAGE_SUBDIR: &str = "datasets";
 const DEFAULT_NAME: &str = "default";
 const ITEM_FILENAME_DIGITS: usize = 9;
+
+/// The canonical "no limit / all items" sentinel reported in a
+/// [`DatasetItemsListPage`]'s `limit` field when the caller requested no limit.
+/// Matches the value crawlee (JS/Python) uses for an unbounded `getData`. The
+/// binding layers pass `None` for unbounded and never hardcode this themselves.
+pub const ALL_ITEMS_LIMIT: usize = 999_999_999_999;
 
 /// Filesystem-backed dataset client.
 ///
@@ -78,8 +84,13 @@ impl FileSystemDatasetClient {
                 })?
         } else {
             // alias determines directory name just like name does
-            let dir_name = name.as_deref().or(alias.as_deref()).unwrap_or(DEFAULT_NAME);
-            storage_dir.join(STORAGE_SUBDIR).join(dir_name)
+            let base = storage_dir.join(STORAGE_SUBDIR);
+            match name.as_deref().or(alias.as_deref()) {
+                // A user-supplied name/alias must map to a single direct child.
+                Some(dir_name) => validate_subdirectory(&base, dir_name)?,
+                // The default name is a trusted constant, no validation needed.
+                None => base.join(DEFAULT_NAME),
+            }
         };
 
         let metadata_path = path.join(METADATA_FILENAME);
@@ -187,10 +198,15 @@ impl FileSystemDatasetClient {
     }
 
     /// Get a paginated list of dataset items.
+    /// Read a page of dataset items.
+    ///
+    /// `limit` is `None` for "all remaining items" (from `offset` onward); the
+    /// binding layers pass their optional limit straight through rather than
+    /// inventing a sentinel.
     pub async fn get_data(
         &self,
         offset: usize,
-        limit: usize,
+        limit: Option<usize>,
         desc: bool,
         skip_empty: bool,
     ) -> Result<DatasetItemsListPage> {
@@ -229,8 +245,10 @@ impl FileSystemDatasetClient {
             items.reverse();
         }
 
+        // `None` means "all items from offset onward".
+        let effective_limit = limit.unwrap_or(ALL_ITEMS_LIMIT);
         let start = offset.min(total);
-        let end = (offset + limit).min(total);
+        let end = offset.saturating_add(effective_limit).min(total);
         let page_items: Vec<Value> = items[start..end].to_vec();
 
         // Update accessed_at
@@ -244,7 +262,7 @@ impl FileSystemDatasetClient {
         Ok(DatasetItemsListPage {
             count: page_items.len(),
             offset,
-            limit,
+            limit: effective_limit,
             total,
             desc,
             items: page_items,
@@ -274,7 +292,9 @@ impl FileSystemDatasetClient {
             None => page_size,
         };
 
-        let page = self.get_data(offset, fetch_limit, desc, skip_empty).await?;
+        let page = self
+            .get_data(offset, Some(fetch_limit), desc, skip_empty)
+            .await?;
 
         let returned = page.items.len();
         let has_more =
@@ -490,21 +510,27 @@ mod tests {
         }
 
         // Get first 2 items
-        let page = client.get_data(0, 2, false, false).await.unwrap();
+        let page = client.get_data(0, Some(2), false, false).await.unwrap();
         assert_eq!(page.count, 2);
         assert_eq!(page.total, 5);
         assert_eq!(page.items[0]["index"], 1);
         assert_eq!(page.items[1]["index"], 2);
 
         // Get items 3-4 (offset=2, limit=2)
-        let page = client.get_data(2, 2, false, false).await.unwrap();
+        let page = client.get_data(2, Some(2), false, false).await.unwrap();
         assert_eq!(page.count, 2);
         assert_eq!(page.items[0]["index"], 3);
 
         // Descending order
-        let page = client.get_data(0, 5, true, false).await.unwrap();
+        let page = client.get_data(0, Some(5), true, false).await.unwrap();
         assert_eq!(page.items[0]["index"], 5);
         assert_eq!(page.items[4]["index"], 1);
+
+        // No limit (None) returns everything from the offset, and reports the
+        // ALL_ITEMS_LIMIT sentinel back in the page.
+        let page = client.get_data(0, None, false, false).await.unwrap();
+        assert_eq!(page.count, 5);
+        assert_eq!(page.limit, ALL_ITEMS_LIMIT);
     }
 
     #[tokio::test]
@@ -526,7 +552,7 @@ mod tests {
 
         // Reversed order is [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]; offset=2 limit=5
         // should yield the slice [2..7] of that, i.e. [7, 6, 5, 4, 3].
-        let page = client.get_data(2, 5, true, false).await.unwrap();
+        let page = client.get_data(2, Some(5), true, false).await.unwrap();
         assert_eq!(page.count, 5);
         assert_eq!(page.total, 10);
         assert_eq!(page.offset, 2);
@@ -658,6 +684,28 @@ mod tests {
             "reopening alias storage by ID should still have name=None"
         );
         assert_eq!(client3.get_metadata().await.item_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_open_rejects_path_traversal_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        for evil in ["../escape", "../../etc", "nested/inside", "/absolute"] {
+            let result =
+                FileSystemDatasetClient::open(None, Some(evil.to_string()), None, storage_dir)
+                    .await;
+            assert!(
+                result.is_err(),
+                "open should reject traversal name {evil:?}"
+            );
+        }
+
+        // Same protection for alias.
+        let result =
+            FileSystemDatasetClient::open(None, None, Some("../escape".to_string()), storage_dir)
+                .await;
+        assert!(result.is_err(), "open should reject traversal alias");
     }
 
     #[tokio::test]

--- a/crawlee-storage/src/key_value_store.rs
+++ b/crawlee-storage/src/key_value_store.rs
@@ -11,7 +11,8 @@ use crate::models::{
 };
 use crate::utils::{
     atomic_write, crypto_random_object_id, encode_key, find_storage_by_id, json_dumps,
-    json_dumps_value, validate_exclusive_args, Result, StorageError, METADATA_FILENAME,
+    json_dumps_value, validate_exclusive_args, validate_subdirectory, Result, StorageError,
+    METADATA_FILENAME,
 };
 
 const STORAGE_SUBDIR: &str = "key_value_stores";
@@ -73,8 +74,13 @@ impl FileSystemKeyValueStoreClient {
                     StorageError::NotFound(format!("Key-value store with id '{id_val}' not found"))
                 })?
         } else {
-            let dir_name = name.as_deref().or(alias.as_deref()).unwrap_or(DEFAULT_NAME);
-            storage_dir.join(STORAGE_SUBDIR).join(dir_name)
+            let base = storage_dir.join(STORAGE_SUBDIR);
+            match name.as_deref().or(alias.as_deref()) {
+                // A user-supplied name/alias must map to a single direct child.
+                Some(dir_name) => validate_subdirectory(&base, dir_name)?,
+                // The default name is a trusted constant, no validation needed.
+                None => base.join(DEFAULT_NAME),
+            }
         };
 
         let metadata_path = path.join(METADATA_FILENAME);

--- a/crawlee-storage/src/request_queue.rs
+++ b/crawlee-storage/src/request_queue.rs
@@ -10,8 +10,8 @@ use crate::clock::{system_clock, ClockRef};
 use crate::models::{AddRequestsResponse, ProcessedRequest, RequestQueueMetadata};
 use crate::utils::{
     atomic_write, crypto_random_object_id, find_storage_by_id, json_dumps, json_dumps_value,
-    sha256_prefix, unique_key_to_request_id, validate_exclusive_args, Result, StorageError,
-    METADATA_FILENAME,
+    sha256_prefix, unique_key_to_request_id, validate_exclusive_args, validate_subdirectory,
+    Result, StorageError, METADATA_FILENAME,
 };
 
 const STORAGE_SUBDIR: &str = "request_queues";
@@ -148,8 +148,13 @@ impl FileSystemRequestQueueClient {
                     StorageError::NotFound(format!("Request queue with id '{id_val}' not found"))
                 })?
         } else {
-            let dir_name = name.as_deref().or(alias.as_deref()).unwrap_or(DEFAULT_NAME);
-            storage_dir.join(STORAGE_SUBDIR).join(dir_name)
+            let base = storage_dir.join(STORAGE_SUBDIR);
+            match name.as_deref().or(alias.as_deref()) {
+                // A user-supplied name/alias must map to a single direct child.
+                Some(dir_name) => validate_subdirectory(&base, dir_name)?,
+                // The default name is a trusted constant, no validation needed.
+                None => base.join(DEFAULT_NAME),
+            }
         };
 
         let metadata_path = path.join(METADATA_FILENAME);
@@ -402,7 +407,7 @@ impl FileSystemRequestQueueClient {
         }
 
         let content = fs::read_to_string(&file_path).await?;
-        let request: Value = serde_json::from_str(&content)?;
+        let mut request: Value = serde_json::from_str(&content)?;
 
         {
             let mut inner = self.inner.lock().await;
@@ -411,6 +416,7 @@ impl FileSystemRequestQueueClient {
             atomic_write(&self.path.join(METADATA_FILENAME), json.as_bytes()).await?;
         }
 
+        Self::strip_queue_internals(&mut request);
         Ok(Some(request))
     }
 
@@ -489,6 +495,12 @@ impl FileSystemRequestQueueClient {
                     let meta_json = json_dumps_value(&inner.metadata)?;
                     atomic_write(&self.path.join(METADATA_FILENAME), meta_json.as_bytes()).await?;
 
+                    // Strip the queue-owned lock field before handing the
+                    // request to the caller; we persisted the locked orderNo to
+                    // disk above. The caller hands the request back to
+                    // mark_request_as_handled/reclaim_request, which re-derive
+                    // these fields from uniqueKey, so the round-trip is safe.
+                    Self::strip_queue_internals(&mut request);
                     return Ok(Some(request));
                 }
             }
@@ -786,6 +798,16 @@ impl FileSystemRequestQueueClient {
             })
     }
 
+    /// Remove queue-owned bookkeeping fields from a request before returning it
+    /// to the caller. `orderNo` is the lock/ordering state and is purely
+    /// internal; it lives on disk but must never leak to consumers. (`id` is
+    /// kept — it is a stable, caller-meaningful request identifier.)
+    fn strip_queue_internals(request: &mut Value) {
+        if let Value::Object(ref mut map) = request {
+            map.remove("orderNo");
+        }
+    }
+
     fn read_order_no(request: &Value) -> Option<i64> {
         match request.get("orderNo") {
             Some(Value::Number(n)) => n.as_i64(),
@@ -998,6 +1020,16 @@ mod tests {
         })
     }
 
+    /// Read the raw persisted request file straight off disk, bypassing the
+    /// client API. Used by tests that assert on the *on-disk* format (e.g. the
+    /// queue-owned `orderNo`/`id` fields that the client strips before
+    /// returning requests to callers).
+    fn read_persisted_request(client: &FileSystemRequestQueueClient, unique_key: &str) -> Value {
+        let path = client.get_request_path(unique_key);
+        let content = std::fs::read_to_string(path).expect("request file should exist on disk");
+        serde_json::from_str(&content).expect("request file should be valid JSON")
+    }
+
     #[tokio::test]
     async fn test_add_and_fetch_request() {
         let temp_dir = TempDir::new().unwrap();
@@ -1018,6 +1050,41 @@ mod tests {
 
         // Locked now — nothing else fetchable.
         assert!(client.fetch_next_request().await.unwrap().is_none());
+    }
+
+    /// fetch_next_request must not leak the queue-owned `orderNo` lock field to
+    /// the caller, but the lock must still be persisted to disk (so peers skip
+    /// it), and the stripped request must still round-trip through
+    /// mark_request_as_handled.
+    #[tokio::test]
+    async fn test_fetch_next_request_strips_order_no() {
+        let temp_dir = TempDir::new().unwrap();
+        let client = FileSystemRequestQueueClient::open(None, None, None, temp_dir.path())
+            .await
+            .unwrap();
+
+        client
+            .add_batch_of_requests(vec![req("leaky")], false)
+            .await
+            .unwrap();
+
+        let fetched = client.fetch_next_request().await.unwrap().unwrap();
+        assert!(
+            fetched.get("orderNo").is_none(),
+            "fetched request must not expose internal orderNo"
+        );
+
+        // The lock is still on disk (future-dated, so the request is locked).
+        let persisted = read_persisted_request(&client, "leaky");
+        assert!(
+            persisted.get("orderNo").and_then(|v| v.as_i64()).is_some(),
+            "the lock must be persisted to disk even though it's stripped on return"
+        );
+
+        // The stripped request round-trips back into mark_request_as_handled.
+        let result = client.mark_request_as_handled(fetched).await.unwrap();
+        assert!(result.is_some());
+        assert!(client.is_finished().await);
     }
 
     /// Stray non-JSON files (and malformed JSON) dropped into the queue directory must be
@@ -1814,9 +1881,17 @@ mod tests {
             .unwrap();
 
         // The persisted file must carry id + orderNo (the on-disk lock format).
-        let stored = client.get_request("req1").await.unwrap().unwrap();
+        // Read the raw file, not via get_request — the client strips orderNo
+        // from requests it returns to callers.
+        let stored = read_persisted_request(&client, "req1");
         assert!(stored.get("id").and_then(|v| v.as_str()).is_some());
         assert!(stored.get("orderNo").and_then(|v| v.as_i64()).is_some());
+
+        // get_request, by contrast, must NOT leak the internal orderNo lock
+        // field to the caller (id is kept).
+        let returned = client.get_request("req1").await.unwrap().unwrap();
+        assert!(returned.get("orderNo").is_none());
+        assert!(returned.get("id").and_then(|v| v.as_str()).is_some());
     }
 
     /// Adding a request that already carries a `handledAt` must store it as
@@ -1869,7 +1944,8 @@ mod tests {
         );
 
         // The persisted file must carry orderNo: null so re-readers agree.
-        let stored = client.get_request("done").await.unwrap().unwrap();
+        // Read the raw file, since get_request strips orderNo on return.
+        let stored = read_persisted_request(&client, "done");
         assert!(
             stored.get("orderNo").map(|v| v.is_null()).unwrap_or(false),
             "handled-on-add request must persist with orderNo: null"

--- a/crawlee-storage/src/utils.rs
+++ b/crawlee-storage/src/utils.rs
@@ -177,6 +177,62 @@ pub fn validate_exclusive_args(
     Ok(())
 }
 
+/// Resolve a storage subdirectory inside a base directory, rejecting anything
+/// that does not map to a single direct child of `base_dir`.
+///
+/// Joins `subdirectory` onto `base_dir` and verifies the result is a direct
+/// child of `base_dir`, so a storage name or alias always maps to one
+/// subdirectory under the storage directory rather than a nested path (e.g.
+/// `nested/inside`) or somewhere else entirely (e.g. a value containing `..`
+/// or an absolute path).
+///
+/// Normalization is purely lexical (no filesystem access): symlinks are not
+/// followed and the check is deterministic. Mirrors the Python
+/// `validate_subdirectory` helper.
+pub fn validate_subdirectory(base_dir: &Path, subdirectory: &str) -> Result<std::path::PathBuf> {
+    let target = normalize_lexically(&base_dir.join(subdirectory));
+    let base = normalize_lexically(base_dir);
+
+    // The target must be a direct child of the base directory: its parent,
+    // after lexical normalization, must equal the normalized base. This rejects
+    // path separators, parent references ("..") and absolute paths.
+    if target.parent() != Some(base.as_path()) {
+        return Err(StorageError::InvalidArgs(format!(
+            "Invalid storage name or alias \"{subdirectory}\". It must map to a single \
+             subdirectory under the storage directory and must not contain path separators, \
+             parent directory references (\"..\") or absolute paths."
+        )));
+    }
+
+    Ok(target)
+}
+
+/// Lexically normalize a path (no filesystem access): collapse `.`, resolve
+/// `..` against preceding normal components, and preserve a leading root.
+/// Equivalent to Python's `os.path.normpath` for our purposes.
+fn normalize_lexically(path: &Path) -> std::path::PathBuf {
+    use std::path::Component;
+
+    let mut out = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Pop a preceding normal component if there is one; otherwise
+                // keep the `..` so an escaping path stays escaping (and thus
+                // gets rejected by the parent-equality check above).
+                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push(component.as_os_str());
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
 /// Find a storage directory by scanning subdirectories for a matching metadata ID.
 /// Returns the path to the matching subdirectory if found.
 pub async fn find_storage_by_id(
@@ -218,4 +274,47 @@ pub async fn find_storage_by_id(
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_subdirectory_accepts_plain_names() {
+        let base = Path::new("/data/datasets");
+        for name in ["default", "my-store", "Some_Name", "with spaces", "123"] {
+            let got = validate_subdirectory(base, name).expect("plain name should be accepted");
+            assert_eq!(got, base.join(name), "name: {name}");
+        }
+    }
+
+    #[test]
+    fn test_validate_subdirectory_rejects_traversal_and_separators() {
+        let base = Path::new("/data/datasets");
+        for evil in [
+            "..",
+            "../escape",
+            "../../etc/passwd",
+            "nested/inside",
+            "a/b",
+            "/absolute",
+            "/etc/passwd",
+            "foo/..", // normalizes back to base itself, not a child
+            "./..",   // also escapes
+        ] {
+            assert!(
+                validate_subdirectory(base, evil).is_err(),
+                "expected rejection for: {evil:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_subdirectory_collapses_harmless_curdir() {
+        // A leading "./name" normalizes to a direct child and is fine.
+        let base = Path::new("/data/key_value_stores");
+        let got = validate_subdirectory(base, "./store").expect("./store should normalize");
+        assert_eq!(got, base.join("store"));
+    }
 }


### PR DESCRIPTION
- removed the `limit` default value duplicated in both bindings
- stopped leaking the `orderNo` internal field
- started validating filesystem paths
