### PR TITLE
fix: Improve handling of bare KeyValueStore records

### DIFF
--- a/crawlee-storage-node/dts-header.d.ts
+++ b/crawlee-storage-node/dts-header.d.ts
@@ -63,8 +63,17 @@ export interface KvsKeyIterator {
 }
 
 export interface FileSystemKeyValueStoreClient {
-    /** Get a value as a ReadableStream of bytes. Returns null if the key doesn't exist. */
-    getValueStream(key: string): Promise<KeyValueStoreStreamRecord | null>;
+    /**
+     * Get a value as a ReadableStream of bytes. Returns null if the key doesn't exist.
+     *
+     * When `requireRecordMetadata` is `false`, a value file without a metadata
+     * sidecar is also streamable (used to read out-of-band files such as a
+     * CLI-written `INPUT.json`). Defaults to `true` (sidecar required).
+     */
+    getValueStream(
+        key: string,
+        requireRecordMetadata?: boolean,
+    ): Promise<KeyValueStoreStreamRecord | null>;
     /** Set a value from a ReadableStream. Consumes the entire stream and writes atomically. */
     setValueStream(
         key: string,

--- a/crawlee-storage-node/index.d.ts
+++ b/crawlee-storage-node/index.d.ts
@@ -128,7 +128,13 @@ export declare class FileSystemKeyValueStoreClient {
     get pathToMetadata(): string;
     getMetadata(): Promise<KeyValueStoreMetadata>;
     dropStorage(): Promise<void>;
-    purge(): Promise<void>;
+    /**
+     * Delete all records except those whose keys are listed in `keep`.
+     *
+     * Matching is by exact key (no extension globbing): to spare both `INPUT`
+     * and `INPUT.json`, pass both. The store metadata is always kept.
+     */
+    purge(keep?: Array<string> | undefined | null): Promise<void>;
     /** Get a record by key. Returns the raw value bytes as a Buffer. */
     getValue(key: string): Promise<KeyValueStoreRecord | null>;
     /** Set a value from a Buffer. */

--- a/crawlee-storage-node/index.d.ts
+++ b/crawlee-storage-node/index.d.ts
@@ -63,8 +63,17 @@ export interface KvsKeyIterator {
 }
 
 export interface FileSystemKeyValueStoreClient {
-    /** Get a value as a ReadableStream of bytes. Returns null if the key doesn't exist. */
-    getValueStream(key: string): Promise<KeyValueStoreStreamRecord | null>;
+    /**
+     * Get a value as a ReadableStream of bytes. Returns null if the key doesn't exist.
+     *
+     * When `requireRecordMetadata` is `false`, a value file without a metadata
+     * sidecar is also streamable (used to read out-of-band files such as a
+     * CLI-written `INPUT.json`). Defaults to `true` (sidecar required).
+     */
+    getValueStream(
+        key: string,
+        requireRecordMetadata?: boolean,
+    ): Promise<KeyValueStoreStreamRecord | null>;
     /** Set a value from a ReadableStream. Consumes the entire stream and writes atomically. */
     setValueStream(
         key: string,
@@ -135,8 +144,18 @@ export declare class FileSystemKeyValueStoreClient {
      * and `INPUT.json`, pass both. The store metadata is always kept.
      */
     purge(keep?: Array<string> | undefined | null): Promise<void>;
-    /** Get a record by key. Returns the raw value bytes as a Buffer. */
-    getValue(key: string): Promise<KeyValueStoreRecord | null>;
+    /**
+     * Get a record by key. Returns the raw value bytes as a Buffer.
+     *
+     * When `requireRecordMetadata` is `false`, a value file without a metadata
+     * sidecar is also returned (with a generic `application/octet-stream`
+     * content type and no type inference) — used to read out-of-band files such
+     * as a CLI-written `INPUT.json`. Defaults to `true` (sidecar required).
+     */
+    getValue(
+        key: string,
+        requireRecordMetadata?: boolean | undefined | null,
+    ): Promise<KeyValueStoreRecord | null>;
     /** Set a value from a Buffer. */
     setValue(key: string, value: Buffer, contentType?: string | undefined | null): Promise<void>;
     deleteValue(key: string): Promise<void>;
@@ -147,7 +166,14 @@ export declare class FileSystemKeyValueStoreClient {
         prefix?: string | undefined | null,
     ): Promise<KvsKeyIterator>;
     getPublicUrl(key: string): Promise<string>;
-    recordExists(key: string): Promise<boolean>;
+    /**
+     * Check whether a record exists for `key`.
+     *
+     * When `requireRecordMetadata` is `false`, a value file with no metadata
+     * sidecar also counts as existing (matching the relaxed `getValue` lookup).
+     * Defaults to `true` (sidecar required).
+     */
+    recordExists(key: string, requireRecordMetadata?: boolean | undefined | null): Promise<boolean>;
 }
 
 export declare class FileSystemRequestQueueClient {

--- a/crawlee-storage-node/lib.js
+++ b/crawlee-storage-node/lib.js
@@ -43,8 +43,11 @@ FileSystemKeyValueStoreClient.prototype.getValue = async function (...args) {
 
 // getValueStream: returns { key, contentType, size, stream } or null.
 // The stream is a Web ReadableStream<Uint8Array> created from the file on disk.
-FileSystemKeyValueStoreClient.prototype.getValueStream = async function (key) {
-    const info = await this._getValueFileInfo(key);
+FileSystemKeyValueStoreClient.prototype.getValueStream = async function (
+    key,
+    requireRecordMetadata,
+) {
+    const info = await this._getValueFileInfo(key, requireRecordMetadata);
     if (info === null) {
         return null;
     }

--- a/crawlee-storage-node/src/lib.rs
+++ b/crawlee-storage-node/src/lib.rs
@@ -322,10 +322,22 @@ impl FileSystemKeyValueStoreClient {
     }
 
     /// Get a record by key. Returns the raw value bytes as a Buffer.
+    ///
+    /// When `requireRecordMetadata` is `false`, a value file without a metadata
+    /// sidecar is also returned (with a generic `application/octet-stream`
+    /// content type and no type inference) — used to read out-of-band files such
+    /// as a CLI-written `INPUT.json`. Defaults to `true` (sidecar required).
     #[napi(ts_return_type = "Promise<KeyValueStoreRecord | null>")]
-    pub async fn get_value(&self, key: String) -> napi::Result<Option<Value>> {
+    pub async fn get_value(
+        &self,
+        key: String,
+        require_record_metadata: Option<bool>,
+    ) -> napi::Result<Option<Value>> {
         let inner = self.inner.clone();
-        let result = inner.get_value(&key).await.map_err(storage_err)?;
+        let result = inner
+            .get_value(&key, require_record_metadata.unwrap_or(true))
+            .await
+            .map_err(storage_err)?;
 
         match result {
             Some((path, meta)) => {
@@ -371,9 +383,16 @@ impl FileSystemKeyValueStoreClient {
     /// Internal: get file info for a record (path + metadata), used by the JS
     /// wrapper to create a ReadableStream without buffering the entire file.
     #[napi(js_name = "_getValueFileInfo", skip_typescript)]
-    pub async fn get_value_file_info(&self, key: String) -> napi::Result<Option<Value>> {
+    pub async fn get_value_file_info(
+        &self,
+        key: String,
+        require_record_metadata: Option<bool>,
+    ) -> napi::Result<Option<Value>> {
         let inner = self.inner.clone();
-        let result = inner.get_value(&key).await.map_err(storage_err)?;
+        let result = inner
+            .get_value(&key, require_record_metadata.unwrap_or(true))
+            .await
+            .map_err(storage_err)?;
 
         match result {
             Some((path, meta)) => {
@@ -456,9 +475,16 @@ impl FileSystemKeyValueStoreClient {
         self.inner.get_public_url(&key).await
     }
 
+    /// Check whether a record exists for `key`.
+    ///
+    /// When `requireRecordMetadata` is `false`, a value file with no metadata
+    /// sidecar also counts as existing (matching the relaxed `getValue` lookup).
+    /// Defaults to `true` (sidecar required).
     #[napi]
-    pub async fn record_exists(&self, key: String) -> bool {
-        self.inner.record_exists(&key).await
+    pub async fn record_exists(&self, key: String, require_record_metadata: Option<bool>) -> bool {
+        self.inner
+            .record_exists(&key, require_record_metadata.unwrap_or(true))
+            .await
     }
 }
 

--- a/crawlee-storage-node/src/lib.rs
+++ b/crawlee-storage-node/src/lib.rs
@@ -309,9 +309,16 @@ impl FileSystemKeyValueStoreClient {
         self.inner.drop_storage().await.map_err(storage_err)
     }
 
+    /// Delete all records except those whose keys are listed in `keep`.
+    ///
+    /// Matching is by exact key (no extension globbing): to spare both `INPUT`
+    /// and `INPUT.json`, pass both. The store metadata is always kept.
     #[napi]
-    pub async fn purge(&self) -> napi::Result<()> {
-        self.inner.purge().await.map_err(storage_err)
+    pub async fn purge(&self, keep: Option<Vec<String>>) -> napi::Result<()> {
+        self.inner
+            .purge(&keep.unwrap_or_default())
+            .await
+            .map_err(storage_err)
     }
 
     /// Get a record by key. Returns the raw value bytes as a Buffer.

--- a/crawlee-storage-node/test/key_value_store.test.ts
+++ b/crawlee-storage-node/test/key_value_store.test.ts
@@ -158,7 +158,9 @@ describe('FileSystemKeyValueStoreClient', () => {
 
         const url = await client.getPublicUrl('my-key');
         expect(url).toMatch(/^file:\/\//);
-        expect(url).toContain('my%2Dkey');
+        // Hyphen is in the unreserved set (quote(safe='') keeps `. - _ ~`), so it
+        // is preserved verbatim rather than encoded to %2D.
+        expect(url).toContain('my-key');
     });
 
     it('should purge all values but keep metadata', async () => {
@@ -184,6 +186,28 @@ describe('FileSystemKeyValueStoreClient', () => {
         expect(await client.recordExists('INPUT')).toBe(true);
         expect(await client.recordExists('other')).toBe(false);
         expect(existsSync(client.pathToMetadata)).toBe(true);
+    });
+
+    it('should read a sidecar-less file only when requireRecordMetadata is false', async () => {
+        const { writeFile } = await import('fs/promises');
+        const client = await FileSystemKeyValueStoreClient.open(null, null, null, storageDir);
+
+        // Hand-place a bare value file (no metadata sidecar), like a CLI-written INPUT.json.
+        const payload = Buffer.from(JSON.stringify({ foo: 'bar' }));
+        await writeFile(join(client.pathToKvs, 'INPUT.json'), payload);
+
+        // Default (strict): invisible.
+        expect(await client.getValue('INPUT.json')).toBeNull();
+        expect(await client.recordExists('INPUT.json')).toBe(false);
+
+        // Opt-in: served with generic content type, no extension inference.
+        const record = await client.getValue('INPUT.json', false);
+        expect(record).not.toBeNull();
+        expect(record!.key).toBe('INPUT.json');
+        expect(record!.contentType).toBe('application/octet-stream');
+        expect(Buffer.isBuffer(record!.value)).toBe(true);
+        expect(record!.value.equals(payload)).toBe(true);
+        expect(await client.recordExists('INPUT.json', false)).toBe(true);
     });
 
     it('should drop storage entirely', async () => {

--- a/crawlee-storage-node/test/key_value_store.test.ts
+++ b/crawlee-storage-node/test/key_value_store.test.ts
@@ -174,6 +174,18 @@ describe('FileSystemKeyValueStoreClient', () => {
         expect(existsSync(client.pathToMetadata)).toBe(true);
     });
 
+    it('should keep listed keys when purging with a keep list', async () => {
+        const client = await FileSystemKeyValueStoreClient.open(null, null, null, storageDir);
+
+        await client.setValue('INPUT', Buffer.from('in'));
+        await client.setValue('other', Buffer.from('x'));
+
+        await client.purge(['INPUT']);
+        expect(await client.recordExists('INPUT')).toBe(true);
+        expect(await client.recordExists('other')).toBe(false);
+        expect(existsSync(client.pathToMetadata)).toBe(true);
+    });
+
     it('should drop storage entirely', async () => {
         const client = await FileSystemKeyValueStoreClient.open(null, null, null, storageDir);
 

--- a/crawlee-storage-python/python/crawlee_storage/_native/__init__.pyi
+++ b/crawlee-storage-python/python/crawlee_storage/_native/__init__.pyi
@@ -160,12 +160,17 @@ class FileSystemKeyValueStoreClient:
         """
     async def get_metadata(self) -> KeyValueStoreMetadata: ...
     async def drop_storage(self) -> None: ...
-    async def purge(self) -> None: ...
     async def get_value(self, key: builtins.str) -> KeyValueStoreRecord | None: ...
     async def set_value(
         self, key: builtins.str, value: builtins.bytes, content_type: builtins.str | None = None
     ) -> None: ...
-    async def delete_value(self, key: builtins.str) -> None: ...
+    async def purge(self, keep: typing.Sequence[builtins.str] = []) -> None:
+        r"""
+        Delete all records except those whose keys are listed in `keep`.
+
+        Matching is by exact key (no extension globbing): to spare both `INPUT`
+        and `INPUT.json`, pass both. The store metadata is always kept.
+        """
     def iterate_keys(
         self,
         exclusive_start_key: builtins.str | None = None,

--- a/crawlee-storage-python/python/crawlee_storage/_native/__init__.pyi
+++ b/crawlee-storage-python/python/crawlee_storage/_native/__init__.pyi
@@ -160,7 +160,17 @@ class FileSystemKeyValueStoreClient:
         """
     async def get_metadata(self) -> KeyValueStoreMetadata: ...
     async def drop_storage(self) -> None: ...
-    async def get_value(self, key: builtins.str) -> KeyValueStoreRecord | None: ...
+    async def get_value(
+        self, key: builtins.str, require_record_metadata: builtins.bool = True
+    ) -> KeyValueStoreRecord | None:
+        r"""
+        Get a record by key.
+
+        When `require_record_metadata` is `False`, a value file without a metadata
+        sidecar is also returned (with a generic `application/octet-stream` content
+        type and no type inference) — used to read out-of-band files such as a
+        CLI-written `INPUT.json`. Defaults to `True` (sidecar required).
+        """
     async def set_value(
         self, key: builtins.str, value: builtins.bytes, content_type: builtins.str | None = None
     ) -> None: ...
@@ -179,7 +189,14 @@ class FileSystemKeyValueStoreClient:
         prefix: builtins.str | None = None,
     ) -> KvsKeyIterator: ...
     async def get_public_url(self, key: builtins.str) -> builtins.str: ...
-    async def record_exists(self, key: builtins.str) -> builtins.bool: ...
+    async def record_exists(self, key: builtins.str, require_record_metadata: builtins.bool = True) -> builtins.bool:
+        r"""
+        Check whether a record exists for `key`.
+
+        When `require_record_metadata` is `False`, a value file with no metadata
+        sidecar also counts as existing (matching the relaxed `get_value` lookup).
+        Defaults to `True` (sidecar required).
+        """
 
 @typing.final
 class FileSystemRequestQueueClient:

--- a/crawlee-storage-python/src/lib.rs
+++ b/crawlee-storage-python/src/lib.rs
@@ -610,11 +610,26 @@ impl FileSystemKeyValueStoreClient {
         })
     }
 
+    /// Get a record by key.
+    ///
+    /// When `require_record_metadata` is `False`, a value file without a metadata
+    /// sidecar is also returned (with a generic `application/octet-stream` content
+    /// type and no type inference) — used to read out-of-band files such as a
+    /// CLI-written `INPUT.json`. Defaults to `True` (sidecar required).
     #[gen_stub(override_return_type(type_repr = "KeyValueStoreRecord | None"))]
-    fn get_value<'py>(&self, py: Python<'py>, key: String) -> PyResult<Bound<'py, pyo3::PyAny>> {
+    #[pyo3(signature = (key, require_record_metadata=true))]
+    fn get_value<'py>(
+        &self,
+        py: Python<'py>,
+        key: String,
+        require_record_metadata: bool,
+    ) -> PyResult<Bound<'py, pyo3::PyAny>> {
         let client = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let result = client.get_value(&key).await.map_err(storage_err)?;
+            let result = client
+                .get_value(&key, require_record_metadata)
+                .await
+                .map_err(storage_err)?;
             match result {
                 Some((path, meta)) => {
                     let data = tokio::fs::read(&path)
@@ -699,15 +714,22 @@ impl FileSystemKeyValueStoreClient {
         })
     }
 
+    /// Check whether a record exists for `key`.
+    ///
+    /// When `require_record_metadata` is `False`, a value file with no metadata
+    /// sidecar also counts as existing (matching the relaxed `get_value` lookup).
+    /// Defaults to `True` (sidecar required).
     #[gen_stub(override_return_type(type_repr = "builtins.bool"))]
+    #[pyo3(signature = (key, require_record_metadata=true))]
     fn record_exists<'py>(
         &self,
         py: Python<'py>,
         key: String,
+        require_record_metadata: bool,
     ) -> PyResult<Bound<'py, pyo3::PyAny>> {
         let client = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            Ok(client.record_exists(&key).await)
+            Ok(client.record_exists(&key, require_record_metadata).await)
         })
     }
 }

--- a/crawlee-storage-python/src/lib.rs
+++ b/crawlee-storage-python/src/lib.rs
@@ -610,15 +610,6 @@ impl FileSystemKeyValueStoreClient {
         })
     }
 
-    #[gen_stub(override_return_type(type_repr = "None"))]
-    fn purge<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::PyAny>> {
-        let client = self.inner.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            client.purge().await.map_err(storage_err)?;
-            Ok(())
-        })
-    }
-
     #[gen_stub(override_return_type(type_repr = "KeyValueStoreRecord | None"))]
     fn get_value<'py>(&self, py: Python<'py>, key: String) -> PyResult<Bound<'py, pyo3::PyAny>> {
         let client = self.inner.clone();
@@ -660,11 +651,16 @@ impl FileSystemKeyValueStoreClient {
         })
     }
 
+    /// Delete all records except those whose keys are listed in `keep`.
+    ///
+    /// Matching is by exact key (no extension globbing): to spare both `INPUT`
+    /// and `INPUT.json`, pass both. The store metadata is always kept.
     #[gen_stub(override_return_type(type_repr = "None"))]
-    fn delete_value<'py>(&self, py: Python<'py>, key: String) -> PyResult<Bound<'py, pyo3::PyAny>> {
+    #[pyo3(signature = (keep=vec![]))]
+    fn purge<'py>(&self, py: Python<'py>, keep: Vec<String>) -> PyResult<Bound<'py, pyo3::PyAny>> {
         let client = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            client.delete_value(&key).await.map_err(storage_err)?;
+            client.purge(&keep).await.map_err(storage_err)?;
             Ok(())
         })
     }

--- a/crawlee-storage/src/key_value_store.rs
+++ b/crawlee-storage/src/key_value_store.rs
@@ -350,9 +350,19 @@ impl FileSystemKeyValueStoreClient {
     /// The client is a pure byte transport: it returns the raw value bytes (via
     /// the path) and the verbatim `content_type` from the sidecar. Parsing and
     /// value semantics live at the `KeyValueStore` frontend.
+    ///
+    /// When `require_record_metadata` is `true` (the normal case), a record is
+    /// only returned if it has a metadata sidecar; a value file without one is
+    /// treated as absent. When `false`, a value file with no sidecar is still
+    /// returned, with synthesized metadata: `content_type` is the generic
+    /// `application/octet-stream` sentinel (the client never infers a type from
+    /// the file extension — that foreign-file convention lives at the frontend)
+    /// and `size` is the value-file length. This is the escape hatch for reading
+    /// out-of-band files (e.g. a CLI-written `INPUT.json` that has no sidecar).
     pub async fn get_value(
         &self,
         key: &str,
+        require_record_metadata: bool,
     ) -> Result<Option<(PathBuf, KeyValueStoreRecordMetadata)>> {
         let encoded = encode_key(key);
         let value_path = self.path.join(&encoded);
@@ -366,21 +376,43 @@ impl FileSystemKeyValueStoreClient {
             atomic_write(&self.metadata_path(), json.as_bytes()).await?;
         }
 
-        if !value_path.exists() || !sidecar_path.exists() {
+        // The value file is always required.
+        if !value_path.exists() {
             return Ok(None);
         }
 
-        let sidecar_content = fs::read_to_string(&sidecar_path).await?;
-        let mut record_meta: KeyValueStoreRecordMetadata = serde_json::from_str(&sidecar_content)?;
+        if sidecar_path.exists() {
+            let sidecar_content = fs::read_to_string(&sidecar_path).await?;
+            let mut record_meta: KeyValueStoreRecordMetadata =
+                serde_json::from_str(&sidecar_content)?;
 
-        // Backfill `size` for foreign/legacy sidecars that omit it (this
-        // library always writes it, but crawlee-JS / older Python clients may
-        // not) by stating the value file.
-        if record_meta.size.is_none() {
-            if let Ok(file_meta) = fs::metadata(&value_path).await {
-                record_meta.size = Some(file_meta.len() as usize);
+            // Backfill `size` for foreign/legacy sidecars that omit it (this
+            // library always writes it, but crawlee-JS / older Python clients may
+            // not) by stating the value file.
+            if record_meta.size.is_none() {
+                if let Ok(file_meta) = fs::metadata(&value_path).await {
+                    record_meta.size = Some(file_meta.len() as usize);
+                }
             }
+
+            return Ok(Some((value_path, record_meta)));
         }
+
+        // No sidecar. By default that means "not a record"; with the opt-in flag
+        // we still serve the bytes, synthesizing dumb metadata (no type inference).
+        if require_record_metadata {
+            return Ok(None);
+        }
+
+        let size = fs::metadata(&value_path)
+            .await
+            .ok()
+            .map(|file_meta| file_meta.len() as usize);
+        let record_meta = KeyValueStoreRecordMetadata {
+            key: key.to_string(),
+            content_type: "application/octet-stream".to_string(),
+            size,
+        };
 
         Ok(Some((value_path, record_meta)))
     }
@@ -468,11 +500,22 @@ impl FileSystemKeyValueStoreClient {
     }
 
     /// Check if a record exists for a key.
-    pub async fn record_exists(&self, key: &str) -> bool {
+    ///
+    /// When `require_record_metadata` is `true`, both the value file and its
+    /// metadata sidecar must exist. When `false`, a value file alone counts —
+    /// matching the relaxed [`get_value`](Self::get_value) lookup for reading
+    /// out-of-band files that have no sidecar.
+    pub async fn record_exists(&self, key: &str, require_record_metadata: bool) -> bool {
         let encoded = encode_key(key);
         let value_path = self.path.join(&encoded);
+        if !value_path.exists() {
+            return false;
+        }
+        if !require_record_metadata {
+            return true;
+        }
         let sidecar_path = self.path.join(format!("{encoded}.{METADATA_FILENAME}"));
-        value_path.exists() && sidecar_path.exists()
+        sidecar_path.exists()
     }
 }
 
@@ -488,7 +531,7 @@ mod tests {
         client: &FileSystemKeyValueStoreClient,
         key: &str,
     ) -> Option<(Vec<u8>, String, Option<usize>)> {
-        let (path, meta) = client.get_value(key).await.unwrap()?;
+        let (path, meta) = client.get_value(key, true).await.unwrap()?;
         let bytes = tokio::fs::read(&path).await.unwrap();
         Some((bytes, meta.content_type, meta.size))
     }
@@ -636,7 +679,7 @@ mod tests {
         .unwrap();
 
         // get_value backfills from the file length.
-        let (_, meta) = client.get_value(key).await.unwrap().unwrap();
+        let (_, meta) = client.get_value(key, true).await.unwrap().unwrap();
         assert_eq!(meta.size, Some(payload.len()));
 
         // The list/iterate path backfills too.
@@ -709,7 +752,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(client.get_value("nope").await.unwrap().is_none());
+        assert!(client.get_value("nope", true).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -726,9 +769,78 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(client.record_exists("key1").await);
+        assert!(client.record_exists("key1", true).await);
         client.delete_value("key1").await.unwrap();
-        assert!(!client.record_exists("key1").await);
+        assert!(!client.record_exists("key1", true).await);
+    }
+
+    #[tokio::test]
+    async fn test_sidecar_less_read_requires_opt_in() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        let client = FileSystemKeyValueStoreClient::open(None, None, None, storage_dir)
+            .await
+            .unwrap();
+
+        // Hand-place a value file with NO sidecar (e.g. a CLI-written INPUT.json).
+        // The on-disk name is the LITERAL "INPUT.json" — encode_key preserves the
+        // dot (it matches quote(safe='')), so addressing key "INPUT.json" lands on
+        // exactly this file. This is what makes the bare-INPUT probe work.
+        let payload = br#"{"foo":"bar"}"#;
+        assert_eq!(encode_key("INPUT.json"), "INPUT.json");
+        let value_path = client.path().join("INPUT.json");
+        tokio::fs::write(&value_path, payload).await.unwrap();
+
+        // Default (strict): a value file without a sidecar is "not a record".
+        assert!(client
+            .get_value("INPUT.json", true)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(!client.record_exists("INPUT.json", true).await);
+
+        // Opt-in: the bytes are served with synthesized, non-inferred metadata.
+        let (path, meta) = client
+            .get_value("INPUT.json", false)
+            .await
+            .unwrap()
+            .unwrap();
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(bytes, payload);
+        assert_eq!(meta.key, "INPUT.json");
+        // No extension-based MIME inference — the generic sentinel only.
+        assert_eq!(meta.content_type, "application/octet-stream");
+        assert_eq!(meta.size, Some(payload.len()));
+
+        assert!(client.record_exists("INPUT.json", false).await);
+
+        // A genuinely missing file is still absent under either flag.
+        assert!(client.get_value("nope", false).await.unwrap().is_none());
+        assert!(!client.record_exists("nope", false).await);
+    }
+
+    #[tokio::test]
+    async fn test_sidecar_present_ignores_flag() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        let client = FileSystemKeyValueStoreClient::open(None, None, None, storage_dir)
+            .await
+            .unwrap();
+
+        // A properly-written record (value + sidecar) reads identically under
+        // both flag values — the flag only affects the missing-sidecar branch.
+        client
+            .set_value("tracked", b"hi", "text/plain; charset=utf-8".to_string())
+            .await
+            .unwrap();
+
+        for require in [true, false] {
+            let (_, meta) = client.get_value("tracked", require).await.unwrap().unwrap();
+            assert_eq!(meta.content_type, "text/plain; charset=utf-8");
+            assert!(client.record_exists("tracked", require).await);
+        }
     }
 
     #[tokio::test]
@@ -752,9 +864,9 @@ mod tests {
         client.purge(&["INPUT".to_string()]).await.unwrap();
 
         // The kept record (value + sidecar) survives.
-        assert!(client.record_exists("INPUT").await);
+        assert!(client.record_exists("INPUT", true).await);
         // The non-kept tracked record is gone (value + sidecar).
-        assert!(!client.record_exists("other").await);
+        assert!(!client.record_exists("other", true).await);
         // The bare INPUT.json is gone: "INPUT" the key encodes to filename "INPUT",
         // not "INPUT.json", so it is NOT spared. No stem/extension matching.
         assert!(!bare_path.exists());
@@ -781,8 +893,8 @@ mod tests {
 
         client.purge(&[]).await.unwrap();
 
-        assert!(!client.record_exists("a").await);
-        assert!(!client.record_exists("b").await);
+        assert!(!client.record_exists("a", true).await);
+        assert!(!client.record_exists("b", true).await);
         assert!(!client.path().join("INPUT.json").exists());
         // Only the store metadata remains.
         let mut remaining = Vec::new();
@@ -1023,7 +1135,7 @@ mod tests {
         assert_eq!(content_type, "application/json");
 
         // A key that was never written must still be absent.
-        assert!(reopened.get_value("missing").await.unwrap().is_none());
+        assert!(reopened.get_value("missing", true).await.unwrap().is_none());
     }
 
     /// `open()` must tolerate the datetime formats that other writers emit in

--- a/crawlee-storage/src/key_value_store.rs
+++ b/crawlee-storage/src/key_value_store.rs
@@ -134,8 +134,24 @@ impl FileSystemKeyValueStoreClient {
     }
 
     /// Delete all value files but keep store metadata.
-    pub async fn purge(&self) -> Result<()> {
+    ///
+    /// Any key listed in `keep` is spared: both its value file and its metadata
+    /// sidecar are left on disk. Matching is by exact key (encoded to its on-disk
+    /// filename via [`encode_key`]) — no extension globbing or stem matching. A
+    /// caller wanting to preserve, say, both `INPUT` and `INPUT.json` must pass
+    /// both as separate keys. The store-level `__metadata__.json` is always kept.
+    pub async fn purge(&self, keep: &[String]) -> Result<()> {
         let mut meta = self.metadata.lock().await;
+
+        // Build the set of filenames to spare: the store metadata plus, for each
+        // kept key, its value file and its per-record sidecar.
+        let mut keep_files: std::collections::HashSet<String> = std::collections::HashSet::new();
+        keep_files.insert(METADATA_FILENAME.to_string());
+        for key in keep {
+            let encoded = encode_key(key);
+            keep_files.insert(format!("{encoded}.{METADATA_FILENAME}"));
+            keep_files.insert(encoded);
+        }
 
         match fs::read_dir(&self.path).await {
             Ok(mut entries) => {
@@ -143,7 +159,7 @@ impl FileSystemKeyValueStoreClient {
                     let path = entry.path();
                     if path.is_file() {
                         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                            if name != METADATA_FILENAME {
+                            if !keep_files.contains(name) {
                                 let _ = fs::remove_file(&path).await;
                             }
                         }
@@ -713,6 +729,68 @@ mod tests {
         assert!(client.record_exists("key1").await);
         client.delete_value("key1").await.unwrap();
         assert!(!client.record_exists("key1").await);
+    }
+
+    #[tokio::test]
+    async fn test_purge_with_keep_list() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        let client = FileSystemKeyValueStoreClient::open(None, None, None, storage_dir)
+            .await
+            .unwrap();
+
+        let ct = "application/json; charset=utf-8".to_string();
+        client.set_value("INPUT", b"in", ct.clone()).await.unwrap();
+        client.set_value("other", b"x", ct.clone()).await.unwrap();
+
+        // A bare value file (no sidecar) placed out-of-band, NOT in the keep list.
+        let bare_path = client.path().join("INPUT.json");
+        tokio::fs::write(&bare_path, b"bare").await.unwrap();
+
+        // Keep exactly the "INPUT" key — by exact key, with no extension magic.
+        client.purge(&["INPUT".to_string()]).await.unwrap();
+
+        // The kept record (value + sidecar) survives.
+        assert!(client.record_exists("INPUT").await);
+        // The non-kept tracked record is gone (value + sidecar).
+        assert!(!client.record_exists("other").await);
+        // The bare INPUT.json is gone: "INPUT" the key encodes to filename "INPUT",
+        // not "INPUT.json", so it is NOT spared. No stem/extension matching.
+        assert!(!bare_path.exists());
+        // Store metadata is always kept.
+        assert!(client.metadata_path().exists());
+    }
+
+    #[tokio::test]
+    async fn test_purge_empty_keep_list_clears_everything() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage_dir = temp_dir.path();
+
+        let client = FileSystemKeyValueStoreClient::open(None, None, None, storage_dir)
+            .await
+            .unwrap();
+
+        let ct = "application/json; charset=utf-8".to_string();
+        client.set_value("a", b"1", ct.clone()).await.unwrap();
+        client.set_value("b", b"2", ct.clone()).await.unwrap();
+        // A bare file too.
+        tokio::fs::write(client.path().join("INPUT.json"), b"bare")
+            .await
+            .unwrap();
+
+        client.purge(&[]).await.unwrap();
+
+        assert!(!client.record_exists("a").await);
+        assert!(!client.record_exists("b").await);
+        assert!(!client.path().join("INPUT.json").exists());
+        // Only the store metadata remains.
+        let mut remaining = Vec::new();
+        let mut entries = fs::read_dir(client.path()).await.unwrap();
+        while let Some(e) = entries.next_entry().await.unwrap() {
+            remaining.push(e.file_name().to_string_lossy().into_owned());
+        }
+        assert_eq!(remaining, vec![METADATA_FILENAME.to_string()]);
     }
 
     #[tokio::test]

--- a/crawlee-storage/src/utils.rs
+++ b/crawlee-storage/src/utils.rs
@@ -94,10 +94,28 @@ pub async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
 }
 
 /// URL-encode a key for filesystem safety.
-/// Equivalent to Python's `urllib.parse.quote(key, safe='')`.
+///
+/// Equivalent to Python's `urllib.parse.quote(key, safe='')`. CPython's
+/// `quote` keeps an "always safe" set of unreserved characters unescaped —
+/// the ASCII alphanumerics plus `_`, `.`, `-`, and `~` — and `safe=''` only
+/// drops the *extra* safe chars (the default `/`), never the always-safe set.
+///
+/// We therefore start from `NON_ALPHANUMERIC` and remove those four so they
+/// pass through verbatim. This keeps keys like `INPUT.json` as the literal
+/// filename `INPUT.json` — which is what out-of-band writers (e.g. the Apify
+/// CLI) produce, so a relaxed `get_value` can find them. Plain
+/// `NON_ALPHANUMERIC` would over-encode the dot (`.` → `%2E`) and break that.
 pub fn encode_key(key: &str) -> String {
-    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-    utf8_percent_encode(key, NON_ALPHANUMERIC).to_string()
+    use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+
+    // `quote(key, safe='')` leaves the unreserved set `_.-~` unescaped.
+    const ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+        .remove(b'_')
+        .remove(b'.')
+        .remove(b'-')
+        .remove(b'~');
+
+    utf8_percent_encode(key, ENCODE_SET).to_string()
 }
 
 /// URL-decode a filesystem-safe key back to its original form.
@@ -269,6 +287,24 @@ pub async fn find_storage_by_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_encode_key_matches_quote_safe_empty() {
+        // The unreserved set `_ . - ~` is preserved verbatim (matching CPython's
+        // urllib.parse.quote(key, safe='') and crawlee-python). Everything else
+        // non-alphanumeric is percent-encoded.
+        assert_eq!(encode_key("INPUT.json"), "INPUT.json");
+        assert_eq!(encode_key("my-key"), "my-key");
+        assert_eq!(encode_key("a_b.c-d~e"), "a_b.c-d~e");
+        assert_eq!(encode_key("plain123"), "plain123");
+        // Reserved / unsafe chars still get encoded.
+        assert_eq!(encode_key("a/b"), "a%2Fb");
+        assert_eq!(encode_key("a b"), "a%20b");
+        assert_eq!(encode_key("a:b"), "a%3Ab");
+        // Round-trips through decode (and legacy %2E-style encodings still decode).
+        assert_eq!(decode_key(&encode_key("INPUT.json")), "INPUT.json");
+        assert_eq!(decode_key("INPUT%2Ejson"), "INPUT.json");
+    }
 
     #[test]
     fn test_validate_subdirectory_accepts_plain_names() {


### PR DESCRIPTION
- **Add an allowlist option to KVS purge()**
- **Add a require_record_metadata flag to allow reading out-of-band-added records; Do not percent-encode safe characters**
